### PR TITLE
filenamify to v4

### DIFF
--- a/helpers/filenamify-url.js
+++ b/helpers/filenamify-url.js
@@ -1,4 +1,4 @@
-const filenamify = require('filenamify').default;
+const filenamify = require('filenamify');
 
 module.exports = function (input) {
   if (typeof input !== 'string') {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "config": "^4.0.0",
     "ejs": "^3.1.10",
     "express": "^5.1.0",
-    "filenamify": "^6.0.0",
+    "filenamify": "^4.3.0",
     "json2csv": "^6.0.0-alpha.2"
   },
   "devDependencies": {


### PR DESCRIPTION
use filenamify v4 to avoid CommonJS vs ESM conflict that arose on the server when using v6