### PR TITLE
fix type=null bug on back button

### DIFF
--- a/views/inspect.ejs
+++ b/views/inspect.ejs
@@ -12,7 +12,13 @@
     <h1>Inspect LibGuide: <%= item.name %></h1>
     <% const typesParams = new URLSearchParams(); %>
     <% typesParams.set('types',types); %>
-    <%- include ('partials/back-button', { typeString: typesParams.toString() }) %>
+    <% let typeString; %>
+    <% if (typesParams.toString() === 'types=null') { %>
+        <% typeString = ''; %>
+    <% } else { %>
+        <% typeString = typesParams.toString(); %>
+    <% } %>
+    <%- include ('partials/back-button', { typeString }) %>
     <div class="mt-4">
     <form id="kwic-chars-form" method="get">
         <% if (types != undefined) { %>


### PR DESCRIPTION
if no types were specified when an item was viewed, this got translated as "types=null" in the back button querystring; this eliminates that behavior so you return to a page with no types specified (default to all instead of none!)